### PR TITLE
Defaults to HTTP/1.1 for cURL

### DIFF
--- a/alexa_remote_control.sh
+++ b/alexa_remote_control.sh
@@ -26,6 +26,7 @@
 # 2018-02-27: v0.8e added "lastalexa" option for HA-Bridge to send its command to a specific device
 #		(Markus Wennesheimer: https://wennez.wordpress.com/light-on-with-alexa-for-each-room/)
 # 2018-02-27: v0.9 unsuccessful logins will now give a short info how to debug the login
+# 2018-03-09: v0.9a workaround for login problem, force curl to use http1.1
 #
 ###
 #
@@ -54,7 +55,7 @@ CURL='/usr/bin/curl'
 # cURL options
 #  -k : if your cURL cannot verify CA certificates, you'll have to trust any
 #  --compressed : if your cURL was compiled with libz you may use compression
-OPTS='--compressed'
+OPTS='--compressed --http1.1'
 #OPTS='-k --compressed'
 
 # browser identity

--- a/alexa_remote_control.sh
+++ b/alexa_remote_control.sh
@@ -55,8 +55,9 @@ CURL='/usr/bin/curl'
 # cURL options
 #  -k : if your cURL cannot verify CA certificates, you'll have to trust any
 #  --compressed : if your cURL was compiled with libz you may use compression
+#  --http1.1 : cURL defaults to HTTP/2 on HTTPS connections if available
 OPTS='--compressed --http1.1'
-#OPTS='-k --compressed'
+#OPTS='-k --compressed --http1.1'
 
 # browser identity
 BROWSER='Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:58.0) Gecko/20100101 Firefox/58.0'

--- a/alexa_remote_control_plain.sh
+++ b/alexa_remote_control_plain.sh
@@ -3,7 +3,7 @@
 # Amazon Alexa Remote Control (PLAIN shell)
 #  alex(at)loetzimmer.de
 #
-# 2018-02-27: v0.9 (for updates see http://blog.loetzimmer.de/2017/10/amazon-alexa-hort-auf-die-shell-echo.html)
+# 2018-03-09: v0.9a (for updates see http://blog.loetzimmer.de/2017/10/amazon-alexa-hort-auf-die-shell-echo.html)
 #
 ###
 #

--- a/alexa_remote_control_plain.sh
+++ b/alexa_remote_control_plain.sh
@@ -31,7 +31,7 @@ CURL='/usr/bin/curl'
 # cURL options
 #  -k : if your cURL cannot verify CA certificates, you'll have to trust any
 #  --compressed : if your cURL was compiled with libz you may use compression
-OPTS='--compressed'
+OPTS='--compressed --http1.1'
 #OPTS='-k --compressed'
 
 # browser identity

--- a/alexa_remote_control_plain.sh
+++ b/alexa_remote_control_plain.sh
@@ -31,8 +31,9 @@ CURL='/usr/bin/curl'
 # cURL options
 #  -k : if your cURL cannot verify CA certificates, you'll have to trust any
 #  --compressed : if your cURL was compiled with libz you may use compression
+#  --http1.1 : cURL defaults to HTTP/2 on HTTPS connections if available
 OPTS='--compressed --http1.1'
-#OPTS='-k --compressed'
+#OPTS='-k --compressed --http1.1'
 
 # browser identity
 BROWSER='Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:58.0) Gecko/20100101 Firefox/58.0'


### PR DESCRIPTION
Incorporated the patch from @dbrekau 
From the cURL documentation:
 Since 7.47.0, the curl tool enables HTTP/2 by default for HTTPS connections.