### PR TITLE
avoid using "ALL" in option -m as name of group

### DIFF
--- a/alexa_remote_control.sh
+++ b/alexa_remote_control.sh
@@ -252,8 +252,8 @@ while [ "$#" -gt 0 ] ; do
 			fi
 			;;
 		-m)
-			if [ "${2#-}" != "${2}" -o -z "$2" ] ; then
-				echo "ERROR: missing argument for ${1}"
+			if [ "${2#-}" != "${2}" -o -z "$2" -o "$(echo "${2}" | tr [:upper:] [:lower:])" = "all" ] ; then
+				echo "ERROR: missing or invalid argument for ${1}"
 				usage
 				exit 1
 			fi


### PR DESCRIPTION
People may intuitively use "ALL" as groupname in -m when listing all their echos.
That can mess-up with script internal ALL device available to -d option.

The change checks first paramter after -m against "all" case insensitive.
